### PR TITLE
Pull PSRC specific code

### DIFF
--- a/DaySim.Customizations/PSRC/ChoiceModels/Default/Models/PSRC_OtherHomeBasedTourModeModel.cs
+++ b/DaySim.Customizations/PSRC/ChoiceModels/Default/Models/PSRC_OtherHomeBasedTourModeModel.cs
@@ -1,0 +1,22 @@
+﻿using DaySim.Framework.ChoiceModels;
+using DaySim.Framework.Core;
+using DaySim.Framework.DomainModels.Wrappers;
+
+namespace DaySim.ChoiceModels.Default.Models
+{
+    class PSRC_OtherHomeBasedTourModeModel : OtherHomeBasedTourModeModel
+    {
+        protected override void RegionSpecificCustomizations(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper tour, int mode)
+        {
+            //Global.PrintFile.WriteLine("Default PSRC_WorkTourModeModel.RegionSpecificCustomizations2 called");
+
+            if (mode == Global.Settings.Modes.Transit)
+            {
+
+                alternative.AddUtilityTerm(200 + tour.OriginParcel.District, 1);//district specific transit calibration constant
+            }
+
+
+        }
+    }
+}

--- a/DaySim.Customizations/PSRC/ChoiceModels/Default/Models/PSRC_WorkTourModeModel.cs
+++ b/DaySim.Customizations/PSRC/ChoiceModels/Default/Models/PSRC_WorkTourModeModel.cs
@@ -1,0 +1,22 @@
+﻿using DaySim.Framework.ChoiceModels;
+using DaySim.Framework.Core;
+using DaySim.Framework.DomainModels.Wrappers;
+
+namespace DaySim.ChoiceModels.Default.Models
+{
+    class PSRC_WorkTourModeModel : WorkTourModeModel
+    {
+        protected override void RegionSpecificCustomizations(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper tour, int mode)
+        {
+            //Global.PrintFile.WriteLine("Default PSRC_WorkTourModeModel.RegionSpecificCustomizations called");
+
+            if (mode == Global.Settings.Modes.Transit)
+            {
+
+                alternative.AddUtilityTerm(200 + tour.OriginParcel.District, 1);//district specific transit calibration constant
+            }
+
+
+        }
+    }
+}

--- a/DaySim.Customizations/PSRC/PSRC.csproj
+++ b/DaySim.Customizations/PSRC/PSRC.csproj
@@ -66,7 +66,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ChoiceModels\Default\Models\PSRC_OtherHomeBasedTourModeModel.cs" />
     <Compile Include="ChoiceModels\Default\Models\PSRC_OtherTourDestinationModel.cs" />
+    <Compile Include="ChoiceModels\Default\Models\PSRC_WorkTourModeModel.cs" />
     <Compile Include="PathTypeModels\PSRC_PathTypeModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ChoiceModels\H\Models\PSRC_WorkLocationModel.cs" />

--- a/DaySim/ChoiceModels/Default/Models/OtherHomeBasedTourModeModel.cs
+++ b/DaySim/ChoiceModels/Default/Models/OtherHomeBasedTourModeModel.cs
@@ -147,6 +147,12 @@ namespace DaySim.ChoiceModels.Default.Models {
 			return choiceProbabilityCalculator.SimulateChoice(tour.Household.RandomUtility);
 		}
 
+        protected virtual void RegionSpecificCustomizations(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper tour, int mode)
+        {
+            //see PSRC customization dll for example
+            //Global.PrintFile.WriteLine("Generic Default WorkTourModeModel.RegionSpecificCustomizations being called so must not be overridden by CustomizationDll");
+        }
+
 		private void RunModel(ChoiceProbabilityCalculator choiceProbabilityCalculator, ITourWrapper tour, IEnumerable<IPathTypeModel> pathTypeModels, IParcelWrapper destinationParcel, int choice = Constants.DEFAULT_VALUE) {
 			var household = tour.Household;
 			var householdTotals = household.HouseholdTotals;
@@ -325,6 +331,8 @@ namespace DaySim.ChoiceModels.Default.Models {
 					alternative.AddUtilityTerm(175, originParcel.HouseholdDensity1());
 //						alternative.AddUtility(174, originParcel.MixedUse4Index1());
 				}
+
+                RegionSpecificCustomizations(alternative, tour, mode);
 			}
 		}
 	}

--- a/DaySim/ChoiceModels/Default/Models/WorkTourModeModel.cs
+++ b/DaySim/ChoiceModels/Default/Models/WorkTourModeModel.cs
@@ -186,6 +186,12 @@ namespace DaySim.ChoiceModels.Default.Models {
 			return choiceProbabilityCalculator.SimulateChoice(tour.Household.RandomUtility);
 		}
 
+        protected virtual void RegionSpecificCustomizations(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper tour, int mode)
+        {
+            //see PSRC customization dll for example
+            //Global.PrintFile.WriteLine("Generic Default WorkTourModeModel.RegionSpecificCustomizations being called so must not be overridden by CustomizationDll");
+        }
+
 		private void RunModel(ChoiceProbabilityCalculator choiceProbabilityCalculator, ITourWrapper tour, IEnumerable<IPathTypeModel> pathTypeModels, IParcelWrapper destinationParcel, int householdCars, int choice = Constants.DEFAULT_VALUE) {
 			var household = tour.Household;
 			var householdTotals = household.HouseholdTotals;
@@ -387,6 +393,8 @@ namespace DaySim.ChoiceModels.Default.Models {
 //						alternative.AddUtility(175, originParcel.HouseholdDensity1());
 					alternative.AddUtilityTerm(179, originParcel.MixedUse4Index1());
 				}
+
+                RegionSpecificCustomizations(alternative, tour, mode);
 			}
 		}
 	}


### PR DESCRIPTION
This code adds district constants to the transit alternative in WorkTourModeModel and OtherHomeBasedTourModeModel. Please note, I could not get this fork or the develop repo to compile. I got 8 errors like this one:

Error   1   Metadata file 'C:\Temp\new_daysim_test\fork\DaySim\DaySim_dist\DaySim.exe' could not be found   C:\Temp\new_daysim_test\fork\DaySim\DaySim.Customizations\DVRPC\CSC DVRPC
