### PR TITLE
PSRC Region Specific Updates

### DIFF
--- a/DaySim.Customizations/BKR/ChoiceModels/Default/Models/BKR_OtherTourDestinationModel.cs
+++ b/DaySim.Customizations/BKR/ChoiceModels/Default/Models/BKR_OtherTourDestinationModel.cs
@@ -5,7 +5,7 @@ using DaySim.Framework.Core;
 namespace DaySim.ChoiceModels.Default.Models {
   class BKR_OtherTourDestinationModel : OtherTourDestinationModel {
 
-    protected override void RegionSpecificOtherTourDistrictCoefficients(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper _tour, IParcelWrapper destinationParcel) {
+    protected override void RegionSpecificOtherTourDistrictCoefficients(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper _tour, IParcelWrapper destinationParcel,  IPersonWrapper person) {
 
       //add any region-specific new terms in region-specific class, using coefficient numbers 114-120, or other unused variable #
       //Global.PrintFile.WriteLine("PSRC_OtherTourDestinationModel.RegionSpecificOtherTourDistrictCoefficients called");

--- a/DaySim.Customizations/DVRPC/ChoiceModels/Default/Models/DVRPC_OtherTourDestinationModel.cs
+++ b/DaySim.Customizations/DVRPC/ChoiceModels/Default/Models/DVRPC_OtherTourDestinationModel.cs
@@ -6,7 +6,7 @@ using DaySim.Framework.Roster;
 namespace DaySim.ChoiceModels.Default.Models {
   internal class DVRPC_OtherTourDestinationModel : OtherTourDestinationModel {
 
-    protected override void RegionSpecificOtherTourDistrictCoefficients(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper _tour, IParcelWrapper destinationParcel) {
+    protected override void RegionSpecificOtherTourDistrictCoefficients(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper _tour, IParcelWrapper destinationParcel, IPersonWrapper person) {
 
 
       //areas 

--- a/DaySim.Customizations/Fresno/ChoiceModels/Default/Models/Fresno_OtherTourDestinationModel.cs
+++ b/DaySim.Customizations/Fresno/ChoiceModels/Default/Models/Fresno_OtherTourDestinationModel.cs
@@ -5,7 +5,7 @@ using DaySim.Framework.DomainModels.Wrappers;
 namespace DaySim.ChoiceModels.Default.Models {
   internal class Fresno_OtherTourDestinationModel : OtherTourDestinationModel {
 
-    protected override void RegionSpecificOtherTourDistrictCoefficients(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper _tour, IParcelWrapper destinationParcel) {
+    protected override void RegionSpecificOtherTourDistrictCoefficients(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper _tour, IParcelWrapper destinationParcel, IPersonWrapper person) {
 
 
       //add any region-specific new terms in region-specific class, using coefficient numbers 114-120, or other unused variable #

--- a/DaySim.Customizations/JAX/ChoiceModels/Default/Models/JAX_OtherTourDestinationModel.cs
+++ b/DaySim.Customizations/JAX/ChoiceModels/Default/Models/JAX_OtherTourDestinationModel.cs
@@ -6,7 +6,7 @@ using DaySim.Framework.Roster;
 namespace DaySim.ChoiceModels.Default.Models {
   internal class JAX_OtherTourDestinationModel : OtherTourDestinationModel {
 
-    protected override void RegionSpecificOtherTourDistrictCoefficients(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper _tour, IParcelWrapper destinationParcel) {
+    protected override void RegionSpecificOtherTourDistrictCoefficients(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper _tour, IParcelWrapper destinationParcel, IPersonWrapper person) {
 
 
       //add any region-specific new terms in region-specific class, using coefficient numbers 114-120, or other unused variable #

--- a/DaySim.Customizations/PSRC/ChoiceModels/Default/Models/PSRC_OtherHomeBasedTourModeModel.cs
+++ b/DaySim.Customizations/PSRC/ChoiceModels/Default/Models/PSRC_OtherHomeBasedTourModeModel.cs
@@ -2,18 +2,39 @@
 using DaySim.Framework.Core;
 using DaySim.Framework.DomainModels.Wrappers;
 
-namespace DaySim.ChoiceModels.Default.Models {
-  internal class PSRC_OtherHomeBasedTourModeModel : OtherHomeBasedTourModeModel {
-    protected override void RegionSpecificCustomizations(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper tour, int pathType, int mode, IParcelWrapper destinationParcel) {
+namespace DaySim.ChoiceModels.Default.Models
+{
+  internal class PSRC_OtherHomeBasedTourModeModel : OtherHomeBasedTourModeModel
+  {
+    protected override void RegionSpecificCustomizations(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper tour, int pathType, int mode, IParcelWrapper destinationParcel)
+    {
 
       //Global.PrintFile.WriteLine("Default PSRC_OtherHomeBasedTourModeModel.RegionSpecificCustomizations2 called");
 
-      if (mode == Global.Settings.Modes.Transit && pathType != Global.Settings.PathTypes.LightRail && pathType != Global.Settings.PathTypes.CommuterRail && pathType != Global.Settings.PathTypes.Ferry) {
+      if (mode == Global.Settings.Modes.Transit && pathType != Global.Settings.PathTypes.LightRail && pathType != Global.Settings.PathTypes.CommuterRail && pathType != Global.Settings.PathTypes.Ferry)
+      {
 
         alternative.AddUtilityTerm(200 + tour.OriginParcel.District, 1);//district specific transit calibration constant
         alternative.AddUtilityTerm(300 + destinationParcel.District, 1);//district specific transit calibration constant
       }
 
+      if (mode == Global.Settings.Modes.ParkAndRide)
+      {
+        alternative.AddUtilityTerm(250, pathType == 3 ? 1 : 0);
+        alternative.AddUtilityTerm(251, pathType == 4 ? 1 : 0);
+        alternative.AddUtilityTerm(252, pathType == 5 ? 1 : 0);
+        alternative.AddUtilityTerm(253, pathType == 6 ? 1 : 0);
+        alternative.AddUtilityTerm(254, pathType == 7 ? 1 : 0);
+
+      }
+      else if (mode == Global.Settings.Modes.Transit)
+      {
+        alternative.AddUtilityTerm(255, pathType == 3 ? 1 : 0);
+        alternative.AddUtilityTerm(256, pathType == 4 ? 1 : 0);
+        alternative.AddUtilityTerm(257, pathType == 5 ? 1 : 0);
+        alternative.AddUtilityTerm(258, pathType == 6 ? 1 : 0);
+        alternative.AddUtilityTerm(259, pathType == 7 ? 1 : 0);
+      }
 
     }
   }

--- a/DaySim.Customizations/PSRC/ChoiceModels/Default/Models/PSRC_OtherTourDestinationModel.cs
+++ b/DaySim.Customizations/PSRC/ChoiceModels/Default/Models/PSRC_OtherTourDestinationModel.cs
@@ -1,10 +1,12 @@
 ﻿using DaySim.Framework.ChoiceModels;
 using DaySim.Framework.DomainModels.Wrappers;
-
+using DaySim.DomainModels.Extensions;
+using DaySim.Framework.Core;
+using System;
 namespace DaySim.ChoiceModels.Default.Models {
   internal class PSRC_OtherTourDestinationModel : OtherTourDestinationModel {
 
-    protected override void RegionSpecificOtherTourDistrictCoefficients(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper _tour, IParcelWrapper destinationParcel) {
+    protected override void RegionSpecificOtherTourDistrictCoefficients(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper _tour, IParcelWrapper destinationParcel, IPersonWrapper person) {
 
 
       //add any region-specific new terms in region-specific class, using coefficient numbers 114-120, or other unused variable #
@@ -16,7 +18,9 @@ namespace DaySim.ChoiceModels.Default.Models {
       int origTacDestKit = origdist == 8 && destdist == 9 || destdist == 11 ? 1 : 0;
       int origKitDestNotKit = (origdist == 9 || origdist == 11) && (destdist != 9 && destdist != 11) ? 1 : 0;
       int origSTacWorkCBD = (origdist == 11 && destdist == 4) ? 1 : 0;
-
+      double distanceFromOrigin = _tour.OriginParcel.DistanceFromOrigin(destinationParcel, _tour.DestinationArrivalTime);
+      double distanceFromOriginLog = Math.Log(1 + distanceFromOrigin);
+      alternative.AddUtilityTerm(114, person.WorksAtHome().ToFlag() * distanceFromOriginLog);
       alternative.AddUtilityTerm(115, origEastDestCBD);
       alternative.AddUtilityTerm(116, origKitDestTRP);
       alternative.AddUtilityTerm(117, origTacDestKit);

--- a/DaySim.Customizations/PSRC/ChoiceModels/Default/Models/PSRC_SchoolTourModeModel.cs
+++ b/DaySim.Customizations/PSRC/ChoiceModels/Default/Models/PSRC_SchoolTourModeModel.cs
@@ -2,15 +2,37 @@
 using DaySim.Framework.Core;
 using DaySim.Framework.DomainModels.Wrappers;
 
-namespace DaySim.ChoiceModels.Default.Models {
-  internal class PSRC_SchoolTourModeModel : SchoolTourModeModel {
-    protected override void RegionSpecificCustomizations(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper tour, int pathType, int mode, IParcelWrapper destinationParcel) {
+namespace DaySim.ChoiceModels.Default.Models
+{
+  internal class PSRC_SchoolTourModeModel : SchoolTourModeModel
+  {
+    protected override void RegionSpecificCustomizations(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper tour, int pathType, int mode, IParcelWrapper destinationParcel)
+    {
       //Global.PrintFile.WriteLine("Default PSRC_SchoolTourModeModel.RegionSpecificCustomizations called");
 
-      if (mode == Global.Settings.Modes.Transit && pathType != Global.Settings.PathTypes.LightRail && pathType != Global.Settings.PathTypes.CommuterRail && pathType != Global.Settings.PathTypes.Ferry) {
+      if (mode == Global.Settings.Modes.Transit && pathType != Global.Settings.PathTypes.LightRail && pathType != Global.Settings.PathTypes.CommuterRail && pathType != Global.Settings.PathTypes.Ferry)
+      {
 
         alternative.AddUtilityTerm(200 + tour.OriginParcel.District, 1);//district specific transit calibration constant
         alternative.AddUtilityTerm(300 + destinationParcel.District, 1);//district specific transit calibration constant
+      }
+
+      if (mode == Global.Settings.Modes.ParkAndRide)
+      {
+        alternative.AddUtilityTerm(250, pathType == 3 ? 1 : 0);
+        alternative.AddUtilityTerm(251, pathType == 4 ? 1 : 0);
+        alternative.AddUtilityTerm(252, pathType == 5 ? 1 : 0);
+        alternative.AddUtilityTerm(253, pathType == 6 ? 1 : 0);
+        alternative.AddUtilityTerm(254, pathType == 7 ? 1 : 0);
+
+      }
+      else if (mode == Global.Settings.Modes.Transit)
+      {
+        alternative.AddUtilityTerm(255, pathType == 3 ? 1 : 0);
+        alternative.AddUtilityTerm(256, pathType == 4 ? 1 : 0);
+        alternative.AddUtilityTerm(257, pathType == 5 ? 1 : 0);
+        alternative.AddUtilityTerm(258, pathType == 6 ? 1 : 0);
+        alternative.AddUtilityTerm(259, pathType == 7 ? 1 : 0);
       }
 
 

--- a/DaySim.Customizations/PSRC/ChoiceModels/Default/Models/PSRC_WorkTourDestinationModel.cs
+++ b/DaySim.Customizations/PSRC/ChoiceModels/Default/Models/PSRC_WorkTourDestinationModel.cs
@@ -1,0 +1,23 @@
+﻿using DaySim.Framework.ChoiceModels;
+using DaySim.Framework.DomainModels.Wrappers;
+using DaySim.DomainModels.Extensions;
+using DaySim.Framework.Core;
+using System;
+namespace DaySim.ChoiceModels.Default.Models
+{
+  internal class PSRC_WorkTourDestinationModel : WorkTourDestinationModel
+  {
+
+    protected override void RegionSpecificWorkTourCustomCoefficients(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper _tour, IParcelWrapper destinationParcel, IPersonWrapper person)
+    {
+
+
+      //add any region-specific new terms in region-specific class, using coefficient numbers 114-120, or other unused variable #
+      //Global.PrintFile.WriteLine("PSRC_OtherTourDestinationModel.RegionSpecificOtherTourDistrictCoefficients called");
+      double distanceFromOrigin = _tour.OriginParcel.DistanceFromOrigin(destinationParcel, _tour.DestinationArrivalTime);
+      double distanceFromOriginLog = Math.Log(1 + distanceFromOrigin);
+      alternative.AddUtilityTerm(100, person.WorksAtHome().ToFlag() * distanceFromOriginLog);
+      
+    }
+  }
+}

--- a/DaySim.Customizations/PSRC/ChoiceModels/Default/Models/PSRC_WorkTourModeModel.cs
+++ b/DaySim.Customizations/PSRC/ChoiceModels/Default/Models/PSRC_WorkTourModeModel.cs
@@ -2,17 +2,39 @@
 using DaySim.Framework.Core;
 using DaySim.Framework.DomainModels.Wrappers;
 
-namespace DaySim.ChoiceModels.Default.Models {
-  internal class PSRC_WorkTourModeModel : WorkTourModeModel {
-    protected override void RegionSpecificCustomizations(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper tour, int pathType, int mode, IParcelWrapper destinationParcel) {
+namespace DaySim.ChoiceModels.Default.Models
+{
+  internal class PSRC_WorkTourModeModel : WorkTourModeModel
+  {
+    protected override void RegionSpecificCustomizations(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper tour, int pathType, int mode, IParcelWrapper destinationParcel)
+    {
       //Global.PrintFile.WriteLine("Default PSRC_WorkTourModeModel.RegionSpecificCustomizations called");
 
-      if (mode == Global.Settings.Modes.Transit && pathType != Global.Settings.PathTypes.LightRail && pathType != Global.Settings.PathTypes.CommuterRail && pathType != Global.Settings.PathTypes.Ferry) {
+      if (mode == Global.Settings.Modes.Transit && pathType != Global.Settings.PathTypes.LightRail && pathType != Global.Settings.PathTypes.CommuterRail && pathType != Global.Settings.PathTypes.Ferry)
+      {
 
         alternative.AddUtilityTerm(200 + tour.OriginParcel.District, 1);//district specific transit calibration constant
         alternative.AddUtilityTerm(300 + destinationParcel.District, 1);//district specific transit calibration constant
       }
 
+      if (mode == Global.Settings.Modes.ParkAndRide)
+      {
+        alternative.AddUtilityTerm(250, pathType == 3 ? 1 : 0);
+        alternative.AddUtilityTerm(251, pathType == 4 ? 1 : 0);
+        alternative.AddUtilityTerm(252, pathType == 5 ? 1 : 0);
+        alternative.AddUtilityTerm(253, pathType == 6 ? 1 : 0);
+        alternative.AddUtilityTerm(254, pathType == 7 ? 1 : 0);
+
+      }
+
+      else if (mode == Global.Settings.Modes.Transit)
+      {
+        alternative.AddUtilityTerm(255, pathType == 3 ? 1 : 0);
+        alternative.AddUtilityTerm(256, pathType == 4 ? 1 : 0);
+        alternative.AddUtilityTerm(257, pathType == 5 ? 1 : 0);
+        alternative.AddUtilityTerm(258, pathType == 6 ? 1 : 0);
+        alternative.AddUtilityTerm(259, pathType == 7 ? 1 : 0);
+      }
 
     }
   }

--- a/DaySim.Customizations/SFCTA/ChoiceModels/Default/Models/SFCTA_OtherTourDestinationModel.cs
+++ b/DaySim.Customizations/SFCTA/ChoiceModels/Default/Models/SFCTA_OtherTourDestinationModel.cs
@@ -4,7 +4,7 @@ using DaySim.Framework.DomainModels.Wrappers;
 namespace DaySim.ChoiceModels.Default.Models {
   internal class SFCTA_OtherTourDestinationModel : OtherTourDestinationModel {
 
-    protected override void RegionSpecificOtherTourDistrictCoefficients(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper _tour, IParcelWrapper destinationParcel) {
+    protected override void RegionSpecificOtherTourDistrictCoefficients(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper _tour, IParcelWrapper destinationParcel, IPersonWrapper person) {
 
 
       //add any region-specific new terms in region-specific class, using coefficient numbers 114-120, or other unused variable #

--- a/DaySim/ChoiceModels/Default/Models/OtherTourDestinationModel.cs
+++ b/DaySim/ChoiceModels/Default/Models/OtherTourDestinationModel.cs
@@ -32,7 +32,7 @@ namespace DaySim.ChoiceModels.Default.Models {
       Initialize(CHOICE_MODEL_NAME, Global.Configuration.OtherTourDestinationModelCoefficients, sampleSize + 1, TOTAL_NESTED_ALTERNATIVES, TOTAL_LEVELS, MAX_PARAMETER);
     }
 
-    protected virtual void RegionSpecificOtherTourDistrictCoefficients(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper tour, IParcelWrapper destinationParcel) {
+    protected virtual void RegionSpecificOtherTourDistrictCoefficients(ChoiceProbabilityCalculator.Alternative alternative, ITourWrapper tour, IParcelWrapper destinationParcel, IPersonWrapper person) {
       //see PSRC_OtherTourDestinationModel for example
       //Global.PrintFile.WriteLine("Generic OtherTourDestinationModel.RegionSpecificOtherTourDistrictCoefficients being called so must not be overridden by CustomizationDll");
     }
@@ -382,7 +382,7 @@ namespace DaySim.ChoiceModels.Default.Models {
         }
 
         //add any region-specific new terms in region-specific class, using coefficient numbers 114-120, or other unused variable #
-        _parentClass.RegionSpecificOtherTourDistrictCoefficients(alternative, _tour, destinationParcel);
+        _parentClass.RegionSpecificOtherTourDistrictCoefficients(alternative, _tour, destinationParcel, person);
 
         // OD shadow pricing
         if (Global.Configuration.ShouldUseODShadowPricing) {

--- a/DaySim/ChoiceModels/Default/Models/SchoolTourModeModel.cs
+++ b/DaySim/ChoiceModels/Default/Models/SchoolTourModeModel.cs
@@ -23,7 +23,7 @@ namespace DaySim.ChoiceModels.Default.Models {
     public const string CHOICE_MODEL_NAME = "SchoolTourModeModel";
     private const int TOTAL_NESTED_ALTERNATIVES = 6;
     private const int TOTAL_LEVELS = 2;
-    private const int MAX_PARAMETER = 199;
+    private const int MAX_PARAMETER = 299;
     private const int THETA_PARAMETER = 99;
 
     private readonly int[] _nestedAlternativeIds = new[] { 0, 19, 19, 20, 21, 21, 22, 22, 23, 24 };


### PR DESCRIPTION
We have updated the following;

- In PSRC_OtherTourDestinationModel, we added a person level variable to handle work at home status and tour distance. This required adding an IPersonWrapper person argument to the RegionSpecificOtherTourDistrictCoefficients function.  We also had to add this argument to all the other regional implementations. 

- We added PSRC_WorkTourDestinationModel module and updated the WorkTourDestinationModel to implement this. Added a new variable to handle work at home status and tour distance.

- Added transit path-type constants for Work, School & Other tour mode choice models in PSRC. Increased MAX_PARAMETER to 299 in SchoolTourModeModel to make this possible.  